### PR TITLE
Carry chunkIndex when splitting chunks

### DIFF
--- a/packages/service/core/dataset/training/controller.ts
+++ b/packages/service/core/dataset/training/controller.ts
@@ -140,7 +140,7 @@ export async function pushDataListToTrainingQueue({
           model,
           q: item.q,
           a: item.a,
-          chunkIndex: item.chunkIndex ?? 0,
+          chunkIndex: item.chunkIndex ?? i,
           weight: weight ?? 0,
           indexes: item.indexes
         }))


### PR DESCRIPTION
目前上传文本至知识库后，每个被切分的文本分块编号（`chunkIndex`）都会被置为 0。

**before:**
![image](https://github.com/chenyaojie/FastGPT/assets/16379565/7497e632-3e49-49a9-8ccd-261163c48702)

**after**
![image](https://github.com/chenyaojie/FastGPT/assets/16379565/8f845f91-2d56-4605-ac1f-78860c438cee)
